### PR TITLE
Make email optional in Engagements.metadata.to object

### DIFF
--- a/tap_hubspot/schemas/engagements.json
+++ b/tap_hubspot/schemas/engagements.json
@@ -96,7 +96,7 @@
             "type": "object",
             "properties": {
               "email": {
-                "type": "string"
+                "type": ["null", "string"]
               }
             }
           }


### PR DESCRIPTION
THe Hubspot API can return this kind of Engagement, where there
is a metadata.to object without any email field.

```
{
    "engagement": {
        "id": 5666194868,
        "portalId": 46372829,
        "active": true,
        "createdAt": 1582624975045,
        "lastUpdated": 1582624975939,
        "createdBy": 9948403,
        "modifiedBy": 9948403,
        "ownerId": 43367479,
        "type": "EMAIL",
        "timestamp": 1582624963804,
        "teamId": 361263,
        "source": "CRM_UI",
        "sourceId": "xxx@yyy.com",
        "allAccessibleTeamIds": [
            361263
        ],
        "bodyPreview": "....",
        "queueMembershipIds": [],
        "bodyPreviewIsTruncated": false,
        "bodyPreviewHtml": "...",
        "gdprDeleted": false
    },
    "associations": {
        "contactIds": [
            68851
        ],
        "companyIds": [],
        "dealIds": [
            1633449883
        ],
        "ownerIds": [],
        "workflowIds": [],
        "ticketIds": [],
        "contentIds": [],
        "quoteIds": []
    },
    "attachments": [],
    "metadata": {
        "from": {},
        "to": [
            {
                "firstName": "John"
            }
        ],
        "cc": [],
        "bcc": [],
        "sender": {},
        "html": "....",
        "emailSendEventId": {},
        "validationSkipped": [],
        "attachedVideoOpened": false,
        "attachedVideoWatched": false
    }
}
```

# Description of change
(write a short description or paste a link to JIRA)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
