### PR TITLE
Use Deal v3 API

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(name='tap-hubspot',
           'requests==2.20.0',
           'backoff==1.3.2',
           'requests_mock==1.3.0',
+          'python-dateutil==2.8.1'
       ],
       extras_require= {
           'dev': [


### PR DESCRIPTION
# Description of change
In order to properly get the deal stage entry / exit date,
we need to use the V3 Deals API.

Previous attempts were mixing the v1 and v3 APIs but weren't
functional.

This approach use only v3 API. However, we've lost the "versions"
of the properties that the v1 API was providing.

# Manual QA steps
 - Run a discovery and then a sync mode
 
# Risks
 - The catalog needs to be regenerated (we don't have as many fields as before)
- The tap is no longer syncing the "versions" of deals properties
 
# Rollback steps
 - revert this branch
